### PR TITLE
adjust log output format and log level setting

### DIFF
--- a/DefaultLogger.go
+++ b/DefaultLogger.go
@@ -10,6 +10,10 @@ func SetLevel(level LevelType) {
 	defaultLogger.SetLevel(level)
 }
 
+func SetGloablLevel(level LevelType) {
+	defaultLogger.SetGlobalLevel(level)
+}
+
 func SetWriter(writer func(string)) {
 	defaultLogger.SetWriter(writer)
 }
@@ -34,6 +38,6 @@ func Error(logType string, data ...interface{}) {
 	defaultLogger.Error(logType, data...)
 }
 
-func LogRequest(app, node, clientIp, fromApp, fromNode, clientId, sessionId, requestId, host string, authLevel, priority int, method, path string, requestHeaders map[string]string, requestData map[string]interface{}, usedTime float32, responseCode int, responseHeaders map[string]string, responseDataLength uint, responseData interface{}, extraInfo map[string]interface{}){
+func LogRequest(app, node, clientIp, fromApp, fromNode, clientId, sessionId, requestId, host string, authLevel, priority int, method, path string, requestHeaders map[string]string, requestData map[string]interface{}, usedTime float32, responseCode int, responseHeaders map[string]string, responseDataLength uint, responseData interface{}, extraInfo map[string]interface{}) {
 	defaultLogger.LogRequest(app, node, clientIp, fromApp, fromNode, clientId, sessionId, requestId, host, authLevel, priority, method, path, requestHeaders, requestData, usedTime, responseCode, responseHeaders, responseDataLength, responseData, extraInfo)
 }


### PR DESCRIPTION
1、日志输出 增加文件名与行号
      备注： 没有打算支持windows, 有空再整
2、增加了一个全局设置日志等级入口
       解释： 在某些场景下，有需要设置一个全局性日志等级需求，也有在某个模块里为了调试方便降低日志等级的使用场景
