### PR TITLE
增加日志基本输出

### DIFF
--- a/DefaultLogger.go
+++ b/DefaultLogger.go
@@ -1,6 +1,6 @@
 package log
 
-var defaultLogger = Logger{}
+var defaultLogger = &Logger{}
 
 func init() {
 	defaultLogger.SetTruncations("github.com/", "/ssgo/")
@@ -23,19 +23,19 @@ func SetTruncations(truncations ...string) {
 }
 
 func Debug(logType string, data ...interface{}) {
-	defaultLogger.Debug(logType, data...)
+	output(defaultLogger, DEBUG, logType, buildLogData(data...))
 }
 
 func Info(logType string, data ...interface{}) {
-	defaultLogger.Info(logType, data...)
+	output(defaultLogger, INFO, logType, buildLogData(data...))
 }
 
 func Warning(logType string, data ...interface{}) {
-	defaultLogger.Warning(logType, data...)
+	output(defaultLogger, WARNING, logType, buildLogData(data...))
 }
 
 func Error(logType string, data ...interface{}) {
-	defaultLogger.Error(logType, data...)
+	output(defaultLogger, ERROR, logType, buildLogData(data...))
 }
 
 func LogRequest(app, node, clientIp, fromApp, fromNode, clientId, sessionId, requestId, host string, authLevel, priority int, method, path string, requestHeaders map[string]string, requestData map[string]interface{}, usedTime float32, responseCode int, responseHeaders map[string]string, responseDataLength uint, responseData interface{}, extraInfo map[string]interface{}) {

--- a/DefaultLogger.go
+++ b/DefaultLogger.go
@@ -10,6 +10,10 @@ func SetLevel(level LevelType) {
 	defaultLogger.SetLevel(level)
 }
 
+func SetGloablLevel(level LevelType) {
+	defaultLogger.SetGlobalLevel(level)
+}
+
 func SetWriter(writer func(string)) {
 	defaultLogger.SetWriter(writer)
 }
@@ -34,6 +38,6 @@ func Error(logType string, data ...interface{}) {
 	defaultLogger.Error(logType, data...)
 }
 
-func LogRequest(app, node, clientIp, fromApp, fromNode, clientId, sessionId, requestId, host string, authLevel, priority int, method, path string, requestHeaders map[string]string, requestData map[string]interface{}, usedTime float32, responseCode int, responseHeaders map[string]string, responseDataLength uint, responseData interface{}, extraInfo map[string]interface{}){
+func LogRequest(app, node, clientIp, fromApp, fromNode, clientId, sessionId, requestId, host string, authLevel, priority int, method, path string, requestHeaders map[string]string, requestData map[string]interface{}, usedTime float32, responseCode int, responseHeaders map[string]string, responseDataLength uint, responseData interface{}, extraInfo map[string]interface{}) {
 	defaultLogger.LogRequest(app, node, clientIp, fromApp, fromNode, clientId, sessionId, requestId, host, authLevel, priority, method, path, requestHeaders, requestData, usedTime, responseCode, responseHeaders, responseDataLength, responseData, extraInfo)
 }

--- a/Logger.go
+++ b/Logger.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -82,6 +83,7 @@ func (logger *Logger) log(logLevel LevelType, logType string, data map[string]in
 
 	//TODO not support windows, need to deal with path split char :
 	_, fileName, lineNum, _ := runtime.Caller(2)
+	fileName = filepath.Base(fileName)
 	b := strings.Builder{}
 	b.WriteString(fileName)
 	b.WriteString(":")

--- a/Logger.go
+++ b/Logger.go
@@ -45,11 +45,11 @@ func (logger *Logger) SetTruncations(truncations ...string) {
 }
 
 func (logger *Logger) Debug(logType string, data ...interface{}) {
-	logger.log(DEBUG, logType, buildLogData(data...))
+	output(logger, DEBUG, logType, buildLogData(data...))
 }
 
 func (logger *Logger) Info(logType string, data ...interface{}) {
-	logger.log(INFO, logType, buildLogData(data...))
+	output(logger, INFO, logType, buildLogData(data...))
 }
 
 func (logger *Logger) Warning(logType string, data ...interface{}) {
@@ -61,6 +61,10 @@ func (logger *Logger) Error(logType string, data ...interface{}) {
 }
 
 func (logger *Logger) log(logLevel LevelType, logType string, data map[string]interface{}) {
+	output(logger, logLevel, logType, data)
+}
+
+func output(logger *Logger, logLevel LevelType, logType string, data map[string]interface{}) {
 	settedLevel := logger.level
 	if settedLevel == 0 {
 		settedLevel = globalLevelType
@@ -81,7 +85,6 @@ func (logger *Logger) log(logLevel LevelType, logType string, data map[string]in
 		LogLevelName = standard.LogLevelError
 	}
 
-	//TODO not support windows, need to deal with path split char :
 	_, fileName, lineNum, _ := runtime.Caller(2)
 	fileName = filepath.Base(fileName)
 	b := strings.Builder{}
@@ -139,7 +142,7 @@ func (logger *Logger) trace(LogLevel LevelType, logType string, data map[string]
 		traces = append(traces, fmt.Sprintf("%s:%d", file, line))
 	}
 	data[standard.LogFieldTraces] = strings.Join(traces, "; ")
-	logger.log(LogLevel, logType, data)
+	output(logger, LogLevel, logType, data)
 }
 
 func buildLogData(args ...interface{}) map[string]interface{} {


### PR DESCRIPTION
1、 增加日志基本输出 文件名和行号

2、增加日志全局设置日志等级入口
针对场景： 需要在独立的模块里降低日志等级以方便调试，私有日志等级会覆盖全局日志等级